### PR TITLE
Fix parseType reading tokens without checking to see if there are any available

### DIFF
--- a/source/Parser/Parser.cpp
+++ b/source/Parser/Parser.cpp
@@ -970,6 +970,7 @@ namespace Parser
 			std::string baseType = tmp.text;
 
 			// parse until we get a non-identifier and non-scoperes
+			if (tokens.size() > 0)
 			{
 				bool expectingScope = true;
 				Token t = tokens.front();


### PR DESCRIPTION
While parsing LibCInterface.flx, the compiler would segfault as a result of trying to copy a non-existent token at the end of the file. This fixes the issue by reading more tokens only if tokens are actually available.
