### PR TITLE
Simplify normaliseType by caching pointer-to-type

### DIFF
--- a/source/FlaxIR/Types/ClassType.cpp
+++ b/source/FlaxIR/Types/ClassType.cpp
@@ -27,7 +27,7 @@ namespace fir
 		ClassType* type = new ClassType(name, members, methods);
 
 		// special: need to check if new type has the same name
-		for(auto t : tc->typeCache[0])
+		for(auto t : tc->typeCache)
 		{
 			if(t->isClassType() && t->toClassType()->getClassName() == name)
 			{
@@ -56,7 +56,7 @@ namespace fir
 		iceAssert(tc && "null type context");
 
 		// special case: if no body, just return a type of the existing name.
-		for(auto t : tc->typeCache[0])
+		for(auto &t : tc->typeCache)
 		{
 			if(t->isClassType() && t->toClassType()->getClassName() == name)
 				return t->toClassType();

--- a/source/FlaxIR/Types/EnumType.cpp
+++ b/source/FlaxIR/Types/EnumType.cpp
@@ -91,7 +91,7 @@ namespace fir
 		EnumType* type = new EnumType(name, caseType, _cases);
 
 		// special: need to check if new type has the same name
-		for(auto t : tc->typeCache[0])
+		for(auto t : tc->typeCache)
 		{
 			if(t->isEnumType() && t->toEnumType()->getEnumName() == name)
 			{

--- a/source/FlaxIR/Types/StructType.cpp
+++ b/source/FlaxIR/Types/StructType.cpp
@@ -24,7 +24,7 @@ namespace fir
 		StructType* type = new StructType(name, members, packed);
 
 		// special: need to check if new type has the same name
-		for(auto t : tc->typeCache[0])
+		for(auto t : tc->typeCache)
 		{
 			if(t->isStructType() && t->toStructType()->getStructName() == name)
 			{
@@ -52,7 +52,7 @@ namespace fir
 		iceAssert(tc && "null type context");
 
 		// special case: if no body, just return a type of the existing name.
-		for(auto t : tc->typeCache[0])
+		for(auto &t : tc->typeCache)
 		{
 			if(t->isStructType() && t->toStructType()->getStructName() == name)
 				return t->toStructType();

--- a/source/FlaxIR/Types/Type.cpp
+++ b/source/FlaxIR/Types/Type.cpp
@@ -29,18 +29,20 @@ namespace fir
 		if(Type::areTypesEqual(type, this->voidType))
 			return this->voidType;
 
-		size_t ind = getIndirections(type);
-		std::vector<Type*>& list = this->typeCache[ind];
+		// pointer types are guaranteed to be unique due to internal caching
+		// see getPointerTo
+		if(type->isPointerType())
+			return type;
 
 		// find in the list.
 		// todo: make this more efficient
-		for(auto t : list)
+		for(auto t : typeCache)
 		{
 			if(Type::areTypesEqual(t, type))
 				return t;
 		}
 
-		list.push_back(type);
+		typeCache.push_back(type);
 		return type;
 	}
 
@@ -112,7 +114,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[1].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 
 
@@ -124,7 +126,7 @@ namespace fir
 			t->isTypeSigned = true;
 
 			tc->primitiveTypes[8].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// int16
 		{
@@ -132,7 +134,7 @@ namespace fir
 			t->isTypeSigned = true;
 
 			tc->primitiveTypes[16].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// int32
 		{
@@ -140,7 +142,7 @@ namespace fir
 			t->isTypeSigned = true;
 
 			tc->primitiveTypes[32].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// int64
 		{
@@ -148,7 +150,7 @@ namespace fir
 			t->isTypeSigned = true;
 
 			tc->primitiveTypes[64].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// int128
 		{
@@ -156,7 +158,7 @@ namespace fir
 			t->isTypeSigned = true;
 
 			tc->primitiveTypes[128].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 
 
@@ -168,7 +170,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[8].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// uint16
 		{
@@ -176,7 +178,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[16].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// uint32
 		{
@@ -184,7 +186,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[32].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// uint64
 		{
@@ -192,7 +194,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[64].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// uint128
 		{
@@ -200,7 +202,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[128].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 
 
@@ -212,7 +214,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[32].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// float64
 		{
@@ -220,7 +222,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[64].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// float80
 		{
@@ -228,7 +230,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[80].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 		// float128
 		{
@@ -236,7 +238,7 @@ namespace fir
 			t->isTypeSigned = false;
 
 			tc->primitiveTypes[128].push_back(t);
-			tc->typeCache[0].push_back(t);
+			tc->typeCache.push_back(t);
 		}
 
 		return tc;

--- a/source/FlaxIR/Types/Type.cpp
+++ b/source/FlaxIR/Types/Type.cpp
@@ -302,13 +302,19 @@ namespace fir
 		if(!tc) tc = getDefaultFTContext();
 		iceAssert(tc && "null type context");
 
+		// cache the pointer internally
+		if (!pointerTo) {
+			PointerType* newType = new PointerType(this);
+			PointerType* normalised = dynamic_cast<PointerType*>(tc->normaliseType(newType));
 
-		PointerType* newType = new PointerType(this);
+			iceAssert(newType);
+			// the type shouldn't be in the global cache at this point yet
+			iceAssert(normalised == newType);
 
-		// get or create.
-		newType = dynamic_cast<PointerType*>(tc->normaliseType(newType));
-		iceAssert(newType);
-		return newType;
+			pointerTo = normalised;
+		}
+
+		return pointerTo;
 	}
 
 	Type* Type::getPointerElementType(FTContext* tc)

--- a/source/FlaxIR/Types/Type.cpp
+++ b/source/FlaxIR/Types/Type.cpp
@@ -330,7 +330,9 @@ namespace fir
 		iceAssert(ptrthis);
 
 		Type* newType = ptrthis->baseType;
-		newType = tc->normaliseType(newType);
+		// ptrthis could only have been obtained by calling getPointerTo
+		// on an already normalised type, so this should not be needed
+		// newType = tc->normaliseType(newType);
 
 		return newType;
 	}
@@ -361,8 +363,9 @@ namespace fir
 			for(ssize_t i = 0; i < -times; i++)
 				ret = ret->getPointerElementType();
 		}
-
-		ret = tc->normaliseType(ret);
+		// both getPointerTo and getPointerElementType should already
+		// return normalised types
+		// ret = tc->normaliseType(ret);
 		return ret;
 	}
 

--- a/source/include/ir/type.h
+++ b/source/include/ir/type.h
@@ -55,8 +55,7 @@ namespace fir
 		// fir::LLVMContext* llvmContext = 0;
 		fir::Module* module = 0;
 
-		// keyed by number of indirections
-		std::unordered_map<size_t, std::vector<Type*>> typeCache;
+		std::vector<Type*> typeCache;
 		Type* normaliseType(Type* type);
 	};
 

--- a/source/include/ir/type.h
+++ b/source/include/ir/type.h
@@ -188,6 +188,8 @@ namespace fir
 		// base things
 		size_t id = 0;
 
+		PointerType * pointerTo = nullptr;
+
 		static Type* getOrCreateFloatingTypeWithConstraints(FTContext* tc, size_t bits);
 		static Type* getOrCreateIntegerTypeWithConstraints(FTContext* tc, bool issigned, size_t bits);
 		static Type* getOrCreateArrayTypeWithConstraints(FTContext* tc, size_t arrsize, Type* elm);


### PR DESCRIPTION
I recommend looking at the commits individually

This speeds up compilation of test.flx from 800ms to 700ms on my VM.

I didn't worry about cleaning up nicely because neither did you.

Welp, "simplify" and more additions than deletions. Most are comments tho.