### PR TITLE
Save 20% of memory with this one weird trick

### DIFF
--- a/source/Frontend/FileReader.cpp
+++ b/source/Frontend/FileReader.cpp
@@ -61,24 +61,22 @@ namespace Compiler
 
 
 		Parser::Pin pos;
-		Parser::TokenList ts;
-		Parser::Token curtok;
-		FileInnards innards;
+		FileInnards& innards = fileList[fullPath];
 		{
 			auto p = prof::Profile("things");
 			pos.file = fullPath;
 
-			innards.lines = rawlines;
-			innards.contents = fileContents;
+
+			innards.lines = std::move(rawlines);
+			innards.contents = std::move(fileContents);
 			innards.isLexing = true;
-
-
-			fileList[fullPath] = innards;
 		}
 
-		std::experimental::string_view fileContentsView = fileContents;
+		std::experimental::string_view fileContentsView = innards.contents;
 
 		auto p = prof::Profile("lex");
+		Parser::TokenList ts;
+		Parser::Token curtok;
 		while((curtok = getNextToken(fileContentsView, pos)).type != Parser::TType::EndOfFile)
 			ts.push_back(curtok);
 
@@ -87,7 +85,7 @@ namespace Compiler
 
 		{
 			auto p = prof::Profile("things2");
-			fileList[fullPath].tokens = ts;
+			fileList[fullPath].tokens = std::move(ts);
 			fileList[fullPath].isLexing = false;
 		}
 	}


### PR DESCRIPTION
Changes ram usage for a 28MB comment-only file from 700MB to 540MB.
Still like 20x the size of the compiled file, but it's *something*.

You probably can remove that profiling block for "things" now.