### PR TITLE
string_view for Pin

### DIFF
--- a/source/Frontend/Errors.cpp
+++ b/source/Frontend/Errors.cpp
@@ -20,7 +20,7 @@ namespace GenError
 {
 	static void printContext(HighlightOptions ops)
 	{
-		auto lines = Compiler::getFileLines(ops.caret.file);
+		auto lines = Compiler::getFileLines(ops.caret.file.to_string());
 		if(lines.size() > ops.caret.line - 1)
 		{
 			std::string orig = lines[ops.caret.line - 1].to_string();
@@ -147,7 +147,7 @@ void __error_gen(HighlightOptions ops, const char* msg, const char* type, bool d
 	// todo: do we want to truncate the file path?
 	// we're doing it now, might want to change (or use a flag)
 
-	std::string filename = Compiler::getFilenameFromPath(ops.caret.file.empty() ? "(unknown)" : ops.caret.file);
+	std::string filename = Compiler::getFilenameFromPath(ops.caret.file.empty() ? "(unknown)" : ops.caret.file.to_string());
 
 	if(ops.caret.line > 0 && ops.caret.col > 0 && ops.caret.file.size() > 0)
 		fprintf(stderr, "%s(%s:%zu:%zu) ", COLOUR_BLACK_BOLD, filename.c_str(), ops.caret.line, ops.caret.col);

--- a/source/Frontend/FileReader.cpp
+++ b/source/Frontend/FileReader.cpp
@@ -89,7 +89,7 @@ namespace Compiler
 		Parser::Pin pos;
 		FileInnards& innards = fileList[fullPath];
 		{
-			pos.file = fullPath;
+			pos.file = getStaticFilename(fullPath);
 
 			innards.lines = std::move(rawlines);
 			innards.contents = std::move(fileContents);
@@ -156,6 +156,14 @@ namespace Compiler
 
 		innards.didLex = true;
 		innards.isLexing = false;
+	}
+
+	std::experimental::string_view getStaticFilename(const std::string &fullPath)
+	{
+		auto it = fileList.find(fullPath);
+		assert(it != fileList.end());
+		
+		return it->first;
 	}
 
 

--- a/source/Frontend/Parser/Parser.cpp
+++ b/source/Frontend/Parser/Parser.cpp
@@ -287,7 +287,7 @@ namespace Parser
 		staticState = &ps;
 
 		// split into lines
-		ps.currentPos.file = filename;
+		ps.currentPos.file = Compiler::getStaticFilename(filename);
 
 		ps.currentPos.line = 1;
 		ps.currentPos.col = 1;
@@ -470,7 +470,7 @@ namespace Parser
 
 		ps.rootNode = new Root();
 
-		ps.currentPos.file = filename;
+		ps.currentPos.file = Compiler::getStaticFilename(filename);
 		ps.currentPos.line = 1;
 		ps.currentPos.col = 1;
 
@@ -3147,7 +3147,7 @@ namespace Parser
 	std::string pinToString(Parser::Pin p)
 	{
 		char* buf = new char[1024];
-		snprintf(buf, 1024, "(%s:%zu:%zu)", p.file.c_str(), p.line, p.col);
+		snprintf(buf, 1024, "(%s:%zu:%zu)", p.file.to_string().c_str(), p.line, p.col);
 
 		std::string ret(buf);
 		delete[] buf;

--- a/source/include/compiler.h
+++ b/source/include/compiler.h
@@ -60,6 +60,7 @@ namespace Compiler
 	std::string resolveImport(Ast::Import* imp, std::string fullPath);
 
 
+	std::experimental::string_view getStaticFilename(const std::string &fullPath);
 	std::string getFileContents(std::string fullPath);
 	Parser::TokenList& getFileTokens(std::string fullPath);
 	std::vector<std::experimental::string_view> getFileLines(std::string fullPath);

--- a/source/include/defs.h
+++ b/source/include/defs.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <deque>
 #include <string>
+#include <experimental/string_view>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -47,9 +48,9 @@ namespace Parser
 	struct Pin
 	{
 		Pin() { }
-		Pin(std::string f, size_t l, size_t c, size_t ln) : file(f), line(l), col(c), len(ln) { }
+		Pin(std::experimental::string_view f, size_t l, size_t c, size_t ln) : file(f), line(l), col(c), len(ln) { }
 
-		std::string file;
+		std::experimental::string_view file;
 		size_t line = 1;
 		size_t col = 1;
 		size_t len = 1;


### PR DESCRIPTION
For comment benchmark, this makes everything ~3x faster and use 2/3 of memory. It'd be even better to just use constant IDs instead of file names (because string comparisons are pointless here), but this is good enough for now.
Just Tokens left to achieve singularity. 